### PR TITLE
[CI] Build the docs with `strict = [:doctest]`, and fix the broken doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,11 +1,16 @@
-using Documenter, SparseArrays
+using SparseArrays
+using Documenter: DocMeta, makedocs, deploydocs
+
+DocMeta.setdocmeta!(SparseArrays, :DocTestSetup, :(using SparseArrays; using LinearAlgebra); recursive=true)
 
 makedocs(
     modules = [SparseArrays],
     sitename = "SparseArrays",
     pages = Any[
         "SparseArrays" => "index.md"
-        ]
+        ];
+    # strict = true,
+    strict = Symbol[:doctest],
     )
 
 deploydocs(repo = "github.com/JuliaLang/SparseArrays.jl.git")


### PR DESCRIPTION
Fixes #2 

This pull request:
1. Builds the docs with `strict = [:doctest]`. This ensures that if there is a doctest failure, then the docs build fails, and gives a red ❌ on CI.
2. Fixes the broken doctests by ensuring that `using SparseArrays; using LinearAlgebra` is always run at the beginning of every `jldoctest` block.