### PR TITLE
Only show the Codecov commit statuses on pull requests; do not show the Codecov commit statuses on commits on `main`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch:
+      default:
+        only_pulls: true # Only show the `codecov/patch` commit status on pull requests.
+    project:
+      default:
+        only_pulls: true # Only show the `codecov/project` commit status on pull requests.


### PR DESCRIPTION
Same motivation as https://github.com/JuliaLang/Pkg.jl/pull/2910